### PR TITLE
Add option ''modernizr' to 'Unused Classes'

### DIFF
--- a/dist/html-inspector.best-practices.js
+++ b/dist/html-inspector.best-practices.js
@@ -85,31 +85,92 @@ HTMLInspector.rules.add(
   )
 })
 
-HTMLInspector.rules.add(
-  "unused-classes",
-  {
-    whitelist: [
+;(function() {
+  var ignored = {
+    defaults: [
       /^js\-/,
       /^supports\-/,
       /^language\-/,
       /^lang\-/
+    ],
+
+    modernizr: [
+      /^no\-/,
+      "js",
+      "flexbox",
+      "flexboxlegacy",
+      "canvas",
+      "canvastext",
+      "webgl",
+      "touch",
+      "geolocation",
+      "postmessage",
+      "websqldatabase",
+      "indexeddb",
+      "hashchange",
+      "history",
+      "draganddrop",
+      "websockets",
+      "rgba",
+      "hsla",
+      "multiplebgs",
+      "backgroundsize",
+      "borderimage",
+      "borderradius",
+      "boxshadow",
+      "textshadow",
+      "opacity",
+      "cssanimations",
+      "csscolumns",
+      "cssgradients",
+      "cssreflections",
+      "csstransforms",
+      "csstransforms3d",
+      "csstransitions",
+      "fontface",
+      "generatedcontent",
+      "video",
+      "audio",
+      "localstorage",
+      "sessionstorage",
+      "webworkers",
+      "applicationcache",
+      "svg",
+      "inlinesvg",
+      "smil",
+      "svgclippaths"
     ]
-  },
-  function(listener, reporter, config) {
+  }
 
-    var css = HTMLInspector.modules.css
-      , classes = css.getClassSelectors()
+  HTMLInspector.rules.add(
+    "unused-classes",
+    {
+      whitelist: ignored.defaults,
+      modernizr: false
+    },
+    function(listener, reporter, config) {
 
-    listener.on("class", function(name) {
-      if (!foundIn(name, config.whitelist) && classes.indexOf(name) < 0) {
-        reporter.warn(
-          "unused-classes",
-          "The class '"
-          + name
-          + "' is used in the HTML but not found in any stylesheet.",
-          this
-        )
+      var css = HTMLInspector.modules.css
+        , classes = css.getClassSelectors()
+
+      listener.on("class", function(name) {
+        var whitelist = config.whitelist
+
+        if (config.modernizr && this.tagName === "HTML") {
+          whitelist = isRegExp(whitelist) ? [whitelist] : whitelist
+          whitelist = whitelist.concat(ignored.modernizr)
+        }
+
+        if (!foundIn(name, whitelist) && classes.indexOf(name) < 0) {
+          reporter.warn(
+            "unused-classes",
+            "The class '"
+            + name
+            + "' is used in the HTML but not found in any stylesheet.",
+            this
+          )
+        }
       }
-    }
-  )
-})
+    )
+  })
+}())

--- a/dist/html-inspector.js
+++ b/dist/html-inspector.js
@@ -1202,34 +1202,95 @@ HTMLInspector.rules.add(
   )
 })
 
-HTMLInspector.rules.add(
-  "unused-classes",
-  {
-    whitelist: [
+;(function() {
+  var ignored = {
+    defaults: [
       /^js\-/,
       /^supports\-/,
       /^language\-/,
       /^lang\-/
+    ],
+
+    modernizr: [
+      /^no\-/,
+      "js",
+      "flexbox",
+      "flexboxlegacy",
+      "canvas",
+      "canvastext",
+      "webgl",
+      "touch",
+      "geolocation",
+      "postmessage",
+      "websqldatabase",
+      "indexeddb",
+      "hashchange",
+      "history",
+      "draganddrop",
+      "websockets",
+      "rgba",
+      "hsla",
+      "multiplebgs",
+      "backgroundsize",
+      "borderimage",
+      "borderradius",
+      "boxshadow",
+      "textshadow",
+      "opacity",
+      "cssanimations",
+      "csscolumns",
+      "cssgradients",
+      "cssreflections",
+      "csstransforms",
+      "csstransforms3d",
+      "csstransitions",
+      "fontface",
+      "generatedcontent",
+      "video",
+      "audio",
+      "localstorage",
+      "sessionstorage",
+      "webworkers",
+      "applicationcache",
+      "svg",
+      "inlinesvg",
+      "smil",
+      "svgclippaths"
     ]
-  },
-  function(listener, reporter, config) {
+  }
 
-    var css = HTMLInspector.modules.css
-      , classes = css.getClassSelectors()
+  HTMLInspector.rules.add(
+    "unused-classes",
+    {
+      whitelist: ignored.defaults,
+      modernizr: false
+    },
+    function(listener, reporter, config) {
 
-    listener.on("class", function(name) {
-      if (!foundIn(name, config.whitelist) && classes.indexOf(name) < 0) {
-        reporter.warn(
-          "unused-classes",
-          "The class '"
-          + name
-          + "' is used in the HTML but not found in any stylesheet.",
-          this
-        )
+      var css = HTMLInspector.modules.css
+        , classes = css.getClassSelectors()
+
+      listener.on("class", function(name) {
+        var whitelist = config.whitelist
+
+        if (config.modernizr && this.tagName === "HTML") {
+          whitelist = isRegExp(whitelist) ? [whitelist] : whitelist
+          whitelist = whitelist.concat(ignored.modernizr)
+        }
+
+        if (!foundIn(name, whitelist) && classes.indexOf(name) < 0) {
+          reporter.warn(
+            "unused-classes",
+            "The class '"
+            + name
+            + "' is used in the HTML but not found in any stylesheet.",
+            this
+          )
+        }
       }
-    }
-  )
-})
+    )
+  })
+}())
 
 ;(function() {
 

--- a/spec/html-inspector-spec.js
+++ b/spec/html-inspector-spec.js
@@ -1229,6 +1229,51 @@ describe("unnecessary-elements", function() {
 describe("unused-classes", function() {
 
   var log
+    , modernizrClasses = [
+        "js", "no-js",
+        "flexbox", "no-flexbox",
+        "flexboxlegacy", "no-flexboxlegacy",
+        "canvas", "no-canvas",
+        "canvastext", "no-canvastext",
+        "webgl", "no-webgl",
+        "touch", "no-touch",
+        "geolocation", "no-geolocation",
+        "postmessage", "no-postmessage",
+        "websqldatabase", "no-websqldatabase",
+        "indexeddb", "no-indexeddb",
+        "hashchange", "no-hashchange",
+        "history", "no-history",
+        "draganddrop", "no-draganddrop",
+        "websockets", "no-websockets",
+        "rgba", "no-rgba",
+        "hsla", "no-hsla",
+        "multiplebgs", "no-multiplebgs",
+        "backgroundsize", "no-backgroundsize",
+        "borderimage", "no-borderimage",
+        "borderradius", "no-borderradius",
+        "boxshadow", "no-boxshadow",
+        "textshadow", "no-textshadow",
+        "opacity", "no-opacity",
+        "cssanimations", "no-cssanimations",
+        "csscolumns", "no-csscolumns",
+        "cssgradients", "no-cssgradients",
+        "cssreflections", "no-cssreflections",
+        "csstransforms", "no-csstransforms",
+        "csstransforms3d", "no-csstransforms3d",
+        "csstransitions", "no-csstransitions",
+        "fontface", "no-fontface",
+        "generatedcontent", "no-generatedcontent",
+        "video", "no-video",
+        "audio", "no-audio",
+        "localstorage", "no-localstorage",
+        "sessionstorage", "no-sessionstorage",
+        "webworkers", "no-webworkers",
+        "applicationcache", "no-applicationcache",
+        "svg", "no-svg",
+        "inlinesvg", "no-inlinesvg",
+        "smil", "no-smil",
+        "svgclippaths", "no-svgclippaths"
+      ]
 
   function onComplete(reports) {
     log = []
@@ -1282,7 +1327,8 @@ describe("unused-classes", function() {
           + '<div class="fizz supports-flexbox">'
           + '  <p class="js-alert buzz">This is just a test</p>'
           + '</div>'
-        )
+      )
+
 
     // the whitelist can be a single RegExp
     HTMLInspector.rules.extend("unused-classes", {whitelist: /fizz|buzz/})
@@ -1310,6 +1356,96 @@ describe("unused-classes", function() {
     expect(log.length).toBe(2)
     expect(log[0].message).toBe("The class 'supports-flexbox' is used in the HTML but not found in any stylesheet.")
     expect(log[1].message).toBe("The class 'js-alert' is used in the HTML but not found in any stylesheet.")
+
+    log = []
+    $html = $('<html></html>', {
+      "class": "js no-js",
+      html: $html
+    })
+    // the whitelist can be a single RegExp with modernizr enabled
+    HTMLInspector.rules.extend("unused-classes", {whitelist: /fizz|buzz/, modernizr: true})
+
+    HTMLInspector.inspect({
+      useRules: ["unused-classes"],
+      domRoot: $html,
+      onComplete: onComplete
+    })
+
+    expect(log.length).toBe(2)
+    expect(log[0].message).toBe("The class 'supports-flexbox' is used in the HTML but not found in any stylesheet.")
+    expect(log[1].message).toBe("The class 'js-alert' is used in the HTML but not found in any stylesheet.")
+
+    log = []
+    // It can also be a list of strings or RegExps with modernizr enabled
+    HTMLInspector.rules.extend("unused-classes", {whitelist: ["fizz", /buz\w/], modernizr: true})
+
+    HTMLInspector.inspect({
+      useRules: ["unused-classes"],
+      domRoot: $html,
+      onComplete: onComplete
+    })
+
+    expect(log.length).toBe(2)
+    expect(log[0].message).toBe("The class 'supports-flexbox' is used in the HTML but not found in any stylesheet.")
+    expect(log[1].message).toBe("The class 'js-alert' is used in the HTML but not found in any stylesheet.")
+
+  })
+
+  it("warns when modernizr isn't non-whitelisted and its classes appear in the HTML tag but not in any stylesheet", function() {
+
+    var $html = $('<html></html>', {
+      "class": modernizrClasses.join(" ")
+    })
+
+    HTMLInspector.rules.extend("unused-classes", {modernizr: false})
+
+    HTMLInspector.inspect({
+      useRules: ["unused-classes"],
+      domRoot: $html,
+      onComplete: onComplete
+    })
+
+    expect(log.length).toBe(modernizrClasses.length)
+    expect(log[0].message).toBe("The class 'js' is used in the HTML but not found in any stylesheet.")
+    expect(log[1].message).toBe("The class 'no-js' is used in the HTML but not found in any stylesheet.")
+
+  })
+
+  it("warns when modernizr is non-whitelisted but its classes don't appear in HTML tag", function() {
+
+    var $html = $('<div></div>', {
+      "class": modernizrClasses.join(" ")
+    })
+
+
+    HTMLInspector.rules.extend("unused-classes", {modernizr: true})
+
+    HTMLInspector.inspect({
+      useRules: ["unused-classes"],
+      domRoot: $html,
+      onComplete: onComplete
+    })
+
+    expect(log.length).toBe(modernizrClasses.length)
+    expect(log[0].message).toBe("The class 'js' is used in the HTML but not found in any stylesheet.")
+    expect(log[1].message).toBe("The class 'no-js' is used in the HTML but not found in any stylesheet.")
+  })
+
+  it("doesn't warn when modernizr classes appear in the HTML tag", function() {
+
+    var $html = $('<html></html>', {
+      "class": modernizrClasses.join(" ")
+    })
+
+    HTMLInspector.rules.extend("unused-classes", {modernizr: true})
+
+    HTMLInspector.inspect({
+      useRules: ["unused-classes"],
+      domRoot: $html,
+      onComplete: onComplete
+    })
+
+    expect(log.length).toBe(0)
 
   })
 

--- a/spec/src/rules/unused-classes-spec.js
+++ b/spec/src/rules/unused-classes-spec.js
@@ -1,6 +1,51 @@
 describe("unused-classes", function() {
 
   var log
+    , modernizrClasses = [
+        "js", "no-js",
+        "flexbox", "no-flexbox",
+        "flexboxlegacy", "no-flexboxlegacy",
+        "canvas", "no-canvas",
+        "canvastext", "no-canvastext",
+        "webgl", "no-webgl",
+        "touch", "no-touch",
+        "geolocation", "no-geolocation",
+        "postmessage", "no-postmessage",
+        "websqldatabase", "no-websqldatabase",
+        "indexeddb", "no-indexeddb",
+        "hashchange", "no-hashchange",
+        "history", "no-history",
+        "draganddrop", "no-draganddrop",
+        "websockets", "no-websockets",
+        "rgba", "no-rgba",
+        "hsla", "no-hsla",
+        "multiplebgs", "no-multiplebgs",
+        "backgroundsize", "no-backgroundsize",
+        "borderimage", "no-borderimage",
+        "borderradius", "no-borderradius",
+        "boxshadow", "no-boxshadow",
+        "textshadow", "no-textshadow",
+        "opacity", "no-opacity",
+        "cssanimations", "no-cssanimations",
+        "csscolumns", "no-csscolumns",
+        "cssgradients", "no-cssgradients",
+        "cssreflections", "no-cssreflections",
+        "csstransforms", "no-csstransforms",
+        "csstransforms3d", "no-csstransforms3d",
+        "csstransitions", "no-csstransitions",
+        "fontface", "no-fontface",
+        "generatedcontent", "no-generatedcontent",
+        "video", "no-video",
+        "audio", "no-audio",
+        "localstorage", "no-localstorage",
+        "sessionstorage", "no-sessionstorage",
+        "webworkers", "no-webworkers",
+        "applicationcache", "no-applicationcache",
+        "svg", "no-svg",
+        "inlinesvg", "no-inlinesvg",
+        "smil", "no-smil",
+        "svgclippaths", "no-svgclippaths"
+      ]
 
   function onComplete(reports) {
     log = []
@@ -54,7 +99,8 @@ describe("unused-classes", function() {
           + '<div class="fizz supports-flexbox">'
           + '  <p class="js-alert buzz">This is just a test</p>'
           + '</div>'
-        )
+      )
+
 
     // the whitelist can be a single RegExp
     HTMLInspector.rules.extend("unused-classes", {whitelist: /fizz|buzz/})
@@ -82,6 +128,96 @@ describe("unused-classes", function() {
     expect(log.length).toBe(2)
     expect(log[0].message).toBe("The class 'supports-flexbox' is used in the HTML but not found in any stylesheet.")
     expect(log[1].message).toBe("The class 'js-alert' is used in the HTML but not found in any stylesheet.")
+
+    log = []
+    $html = $('<html></html>', {
+      "class": "js no-js",
+      html: $html
+    })
+    // the whitelist can be a single RegExp with modernizr enabled
+    HTMLInspector.rules.extend("unused-classes", {whitelist: /fizz|buzz/, modernizr: true})
+
+    HTMLInspector.inspect({
+      useRules: ["unused-classes"],
+      domRoot: $html,
+      onComplete: onComplete
+    })
+
+    expect(log.length).toBe(2)
+    expect(log[0].message).toBe("The class 'supports-flexbox' is used in the HTML but not found in any stylesheet.")
+    expect(log[1].message).toBe("The class 'js-alert' is used in the HTML but not found in any stylesheet.")
+
+    log = []
+    // It can also be a list of strings or RegExps with modernizr enabled
+    HTMLInspector.rules.extend("unused-classes", {whitelist: ["fizz", /buz\w/], modernizr: true})
+
+    HTMLInspector.inspect({
+      useRules: ["unused-classes"],
+      domRoot: $html,
+      onComplete: onComplete
+    })
+
+    expect(log.length).toBe(2)
+    expect(log[0].message).toBe("The class 'supports-flexbox' is used in the HTML but not found in any stylesheet.")
+    expect(log[1].message).toBe("The class 'js-alert' is used in the HTML but not found in any stylesheet.")
+
+  })
+
+  it("warns when modernizr isn't non-whitelisted and its classes appear in the HTML tag but not in any stylesheet", function() {
+
+    var $html = $('<html></html>', {
+      "class": modernizrClasses.join(" ")
+    })
+
+    HTMLInspector.rules.extend("unused-classes", {modernizr: false})
+
+    HTMLInspector.inspect({
+      useRules: ["unused-classes"],
+      domRoot: $html,
+      onComplete: onComplete
+    })
+
+    expect(log.length).toBe(modernizrClasses.length)
+    expect(log[0].message).toBe("The class 'js' is used in the HTML but not found in any stylesheet.")
+    expect(log[1].message).toBe("The class 'no-js' is used in the HTML but not found in any stylesheet.")
+
+  })
+
+  it("warns when modernizr is non-whitelisted but its classes don't appear in HTML tag", function() {
+
+    var $html = $('<div></div>', {
+      "class": modernizrClasses.join(" ")
+    })
+
+
+    HTMLInspector.rules.extend("unused-classes", {modernizr: true})
+
+    HTMLInspector.inspect({
+      useRules: ["unused-classes"],
+      domRoot: $html,
+      onComplete: onComplete
+    })
+
+    expect(log.length).toBe(modernizrClasses.length)
+    expect(log[0].message).toBe("The class 'js' is used in the HTML but not found in any stylesheet.")
+    expect(log[1].message).toBe("The class 'no-js' is used in the HTML but not found in any stylesheet.")
+  })
+
+  it("doesn't warn when modernizr classes appear in the HTML tag", function() {
+
+    var $html = $('<html></html>', {
+      "class": modernizrClasses.join(" ")
+    })
+
+    HTMLInspector.rules.extend("unused-classes", {modernizr: true})
+
+    HTMLInspector.inspect({
+      useRules: ["unused-classes"],
+      domRoot: $html,
+      onComplete: onComplete
+    })
+
+    expect(log.length).toBe(0)
 
   })
 

--- a/src/rules/best-practices/unused-classes.js
+++ b/src/rules/best-practices/unused-classes.js
@@ -1,28 +1,89 @@
-HTMLInspector.rules.add(
-  "unused-classes",
-  {
-    whitelist: [
+;(function() {
+  var ignored = {
+    defaults: [
       /^js\-/,
       /^supports\-/,
       /^language\-/,
       /^lang\-/
+    ],
+
+    modernizr: [
+      /^no\-/,
+      "js",
+      "flexbox",
+      "flexboxlegacy",
+      "canvas",
+      "canvastext",
+      "webgl",
+      "touch",
+      "geolocation",
+      "postmessage",
+      "websqldatabase",
+      "indexeddb",
+      "hashchange",
+      "history",
+      "draganddrop",
+      "websockets",
+      "rgba",
+      "hsla",
+      "multiplebgs",
+      "backgroundsize",
+      "borderimage",
+      "borderradius",
+      "boxshadow",
+      "textshadow",
+      "opacity",
+      "cssanimations",
+      "csscolumns",
+      "cssgradients",
+      "cssreflections",
+      "csstransforms",
+      "csstransforms3d",
+      "csstransitions",
+      "fontface",
+      "generatedcontent",
+      "video",
+      "audio",
+      "localstorage",
+      "sessionstorage",
+      "webworkers",
+      "applicationcache",
+      "svg",
+      "inlinesvg",
+      "smil",
+      "svgclippaths"
     ]
-  },
-  function(listener, reporter, config) {
+  }
 
-    var css = HTMLInspector.modules.css
-      , classes = css.getClassSelectors()
+  HTMLInspector.rules.add(
+    "unused-classes",
+    {
+      whitelist: ignored.defaults,
+      modernizr: false
+    },
+    function(listener, reporter, config) {
 
-    listener.on("class", function(name) {
-      if (!foundIn(name, config.whitelist) && classes.indexOf(name) < 0) {
-        reporter.warn(
-          "unused-classes",
-          "The class '"
-          + name
-          + "' is used in the HTML but not found in any stylesheet.",
-          this
-        )
+      var css = HTMLInspector.modules.css
+        , classes = css.getClassSelectors()
+
+      listener.on("class", function(name) {
+        var whitelist = config.whitelist
+
+        if (config.modernizr && this.tagName === "HTML") {
+          whitelist = isRegExp(whitelist) ? [whitelist] : whitelist
+          whitelist = whitelist.concat(ignored.modernizr)
+        }
+
+        if (!foundIn(name, whitelist) && classes.indexOf(name) < 0) {
+          reporter.warn(
+            "unused-classes",
+            "The class '"
+            + name
+            + "' is used in the HTML but not found in any stylesheet.",
+            this
+          )
+        }
       }
-    }
-  )
-})
+    )
+  })
+}())


### PR DESCRIPTION
I know, it could be easy reach by overriding rule, but i think that there are 2 issues about:
- Modernizr is popular and uses as basic tool to build modern web apps, so many developers would have to list classes on their own to avoid flood of "Unused Classes" warns
- Modernizr adds its classes to HTML tag, what isn't to simple override

Thank you and I'm sorry if something goes wrong - it's just my first pull request ;)
