### PR TITLE
Fix typo in OL attribute list.

### DIFF
--- a/dist/html-inspector.core.js
+++ b/dist/html-inspector.core.js
@@ -737,7 +737,7 @@ HTMLInspector.modules.add("validation", function() {
     },
     "ol": {
       children: "li",
-      attributes: "globals; reversed; start type"
+      attributes: "globals; reversed; start; type"
     },
     "optgroup": {
       children: "option",

--- a/dist/html-inspector.js
+++ b/dist/html-inspector.js
@@ -4,7 +4,7 @@
  * Copyright (c) 2013 Philip Walton <http://philipwalton.com>
  * Released under the MIT license
  *
- * Date: 2013-07-15
+ * Date: 2013-08-01
  */
 
 ;(function(root, document) {
@@ -746,7 +746,7 @@ HTMLInspector.modules.add("validation", function() {
     },
     "ol": {
       children: "li",
-      attributes: "globals; reversed; start type"
+      attributes: "globals; reversed; start; type"
     },
     "optgroup": {
       children: "option",

--- a/spec/html-inspector-spec.js
+++ b/spec/html-inspector-spec.js
@@ -1538,6 +1538,9 @@ describe("validate-attributes", function() {
           + '  <ul type="foo">'
           + '    <li>blah</li>'
           + '  </ul>'
+          + '  <ol type="1">'
+          + '    <li>blah</li>'
+          + '  </ol>'
           + '</div>'
         )
 

--- a/spec/src/rules/validate-attributes-spec.js
+++ b/spec/src/rules/validate-attributes-spec.js
@@ -22,6 +22,9 @@ describe("validate-attributes", function() {
           + '  <ul type="foo">'
           + '    <li>blah</li>'
           + '  </ul>'
+          + '  <ol type="1">'
+          + '    <li>blah</li>'
+          + '  </ol>'
           + '</div>'
         )
 

--- a/src/modules/validation.js
+++ b/src/modules/validation.js
@@ -286,7 +286,7 @@ HTMLInspector.modules.add("validation", function() {
     },
     "ol": {
       children: "li",
-      attributes: "globals; reversed; start type"
+      attributes: "globals; reversed; start; type"
     },
     "optgroup": {
       children: "option",


### PR DESCRIPTION
I think the ol attribute list is missing a semicolon, so here is a fix.
