### PR TITLE
Include src attribute in log output for cross-origin iframes.

### DIFF
--- a/dist/html-inspector.core.js
+++ b/dist/html-inspector.core.js
@@ -326,7 +326,7 @@ var HTMLInspector = (function() {
     if (!Array.isArray(elements)) elements = [elements]
     elements = elements.map(function(el) {
       if (el.nodeName.toLowerCase() == "iframe" && isCrossOrigin(el.src))
-        return "(iframe " + el.src + ")"
+        return "(can't display iframe with cross-origin source: " + el.src + ")"
       else
         return el
     })

--- a/dist/html-inspector.js
+++ b/dist/html-inspector.js
@@ -4,7 +4,7 @@
  * Copyright (c) 2013 Philip Walton <http://philipwalton.com>
  * Released under the MIT license
  *
- * Date: 2013-08-01
+ * Date: 2013-08-04
  */
 
 ;(function(root, document) {
@@ -335,7 +335,7 @@ var HTMLInspector = (function() {
     if (!Array.isArray(elements)) elements = [elements]
     elements = elements.map(function(el) {
       if (el.nodeName.toLowerCase() == "iframe" && isCrossOrigin(el.src))
-        return "(iframe " + el.src + ")"
+        return "(can't display iframe with cross-origin source: " + el.src + ")"
       else
         return el
     })

--- a/src/inspector.js
+++ b/src/inspector.js
@@ -73,7 +73,7 @@ var HTMLInspector = (function() {
     if (!Array.isArray(elements)) elements = [elements]
     elements = elements.map(function(el) {
       if (el.nodeName.toLowerCase() == "iframe" && isCrossOrigin(el.src))
-        return "(iframe " + el.src + ")"
+        return "(can't display iframe with cross-origin source: " + el.src + ")"
       else
         return el
     })


### PR DESCRIPTION
If I have a page with a lot of cross-origin iframes (e.g. social sharing buttons), then it's helpful to have the iframe src included in the output so that they can be tracked down.
