### PR TITLE
Remove main from the unique-elements rule, because it doesn't have to be unique in documents

### DIFF
--- a/src/rules/validation/unique-elements.js
+++ b/src/rules/validation/unique-elements.js
@@ -3,7 +3,7 @@ module.exports = {
   name: "unique-elements",
 
   config: {
-    elements: ["title", "main"]
+    elements: ["title"]
   },
 
   func: function(listener, reporter, config) {

--- a/test/html-inspector-test.js
+++ b/test/html-inspector-test.js
@@ -994,11 +994,9 @@ describe("unique-elements", function() {
       domRoot: html,
       onComplete: onComplete
     })
-    expect(log.length).to.equal(2)
+    expect(log.length).to.equal(1)
     expect(log[0].message).to.equal("The <title> element may only appear once in the document.")
-    expect(log[1].message).to.equal("The <main> element may only appear once in the document.")
     expect(log[0].context).to.deep.equal([html.querySelector("title"), html.querySelectorAll("title")[1]])
-    expect(log[1].context).to.deep.equal([html.querySelector("main"), html.querySelectorAll("main")[1]])
   })
 
   it("doesn't warn when single-use elements appear on the page only once", function() {

--- a/test/html-inspector/rules/unique-elements-test.js
+++ b/test/html-inspector/rules/unique-elements-test.js
@@ -31,11 +31,9 @@ describe("unique-elements", function() {
       domRoot: html,
       onComplete: onComplete
     })
-    expect(log.length).to.equal(2)
+    expect(log.length).to.equal(1)
     expect(log[0].message).to.equal("The <title> element may only appear once in the document.")
-    expect(log[1].message).to.equal("The <main> element may only appear once in the document.")
     expect(log[0].context).to.deep.equal([html.querySelector("title"), html.querySelectorAll("title")[1]])
-    expect(log[1].context).to.deep.equal([html.querySelector("main"), html.querySelectorAll("main")[1]])
   })
 
   it("doesn't warn when single-use elements appear on the page only once", function() {


### PR DESCRIPTION
See https://html.spec.whatwg.org/multipage/semantics.html#the-main-element