### PR TITLE
Replace `exclude` with `excludeElements` in FAQs.

### DIFF
--- a/FAQs.md
+++ b/FAQs.md
@@ -48,7 +48,7 @@ If, for whatever reason, you are unable to change your build of Modernizr, the o
 
 ```js
 HTMLInspector.inspect({
-  exlude: 'html'
+  excludeElements: 'html'
 })
 ```
 


### PR DESCRIPTION
This fixes a documentation bug where the reader is instructed to use the `exclude` option to exclude checking the `<html />` element if he/she is unwilling to change their build of modernizr. 

The correct option is `excludeElements`.

Thanks for the great tool btw :tophat: 