### PR TITLE
Allows noscript tags to be interspersed with script tags.

### DIFF
--- a/html-inspector.js
+++ b/html-inspector.js
@@ -1760,7 +1760,7 @@ module.exports = {
       var el
       // scripts at the end of the elements are safe
       while (el = elements.pop()) {
-        if (el.nodeName.toLowerCase() != "script") break
+        if (el.nodeName.toLowerCase() != "script" && el.nodeName.toLowerCase() != "noscript") break
       }
       elements.forEach(function(el) {
         if (el.nodeName.toLowerCase() == "script") {

--- a/src/rules/best-practices/script-placement.js
+++ b/src/rules/best-practices/script-placement.js
@@ -31,7 +31,7 @@ module.exports = {
       var el
       // scripts at the end of the elements are safe
       while (el = elements.pop()) {
-        if (el.nodeName.toLowerCase() != "script") break
+        if (el.nodeName.toLowerCase() != "script" && el.nodeName.toLowerCase() != "noscript") break
       }
       elements.forEach(function(el) {
         if (el.nodeName.toLowerCase() == "script") {


### PR DESCRIPTION
It is helpful to be able to keep the <noscript> counterpart of a <script> right after its script in order to keep the context clear. But, as it stands, this causes every script prior to the <noscript> tag to fail. This fix ignores both <script> and <noscript> at the end of the stack.